### PR TITLE
fix `Cannot read property 'headers' of undefined`

### DIFF
--- a/src/logging.module.ts
+++ b/src/logging.module.ts
@@ -39,7 +39,7 @@ export class LoggingModule {
           scope: Scope.REQUEST,
           inject: [ROOT_LOGGER, REQUEST],
           useFactory: (rootLogger: Bunyan, request: IncomingMessage) => {
-            const rawId = request.headers[correlationIdHeader];
+            const rawId = request ? request.headers[correlationIdHeader] : [];
             const correlationId = flatten<string | undefined>([rawId])[0] || "NO_CORRELATION_ID_FOUND";
 
             const requestLogger = rootLogger.child({ correlationId });


### PR DESCRIPTION
logging.module throws `Cannot read property 'headers' of undefined` when a provider is retrieved with `TestingModule.resolve()`.

```
TypeError: Cannot read property 'headers' of undefined

      at InstanceWrapper.useFactory [as metatype] (../../node_modules/@eropple/nestjs-bunyan/src/logging.module.ts:42:35)
      at Injector.instantiateClass (../../node_modules/@nestjs/core/injector/injector.js:279:55)
      at callback (../../node_modules/@nestjs/core/injector/injector.js:74:41)
```