### PR TITLE
Not all requests have headers

### DIFF
--- a/src/logging.module.ts
+++ b/src/logging.module.ts
@@ -40,7 +40,7 @@ export class LoggingModule {
           scope: Scope.REQUEST,
           inject: [ROOT_LOGGER, REQUEST],
           useFactory: (rootLogger: Bunyan, request: ExpressRequest) => {
-            const rawId = request ? request.headers[correlationIdHeader] : [];
+            const rawId = (request && request.headers) ? request.headers[correlationIdHeader] : [];
             const correlationId = flatten<string | undefined>([rawId])[0] || "NO_CORRELATION_ID_FOUND";
 
             const requestLogger = rootLogger.child({ correlationId });


### PR DESCRIPTION
Redis microservice requests, for example, have no headers.  The requestLoggerProvider fails in those instances without this fix