### PR TITLE
Add req-id in addition to correlationId to match bunyan standard + hydrow tablet software

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist/
 node_modules
+.idea/
 
 ~*
 *~

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hydrow/nestjs-bunyan",
+  "name": "@eropple/nestjs-bunyan",
   "version": "0.5.7",
   "description": "Module and tooling for request-scoped Bunyan logging in NestJS.",
   "main": "dist",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@eropple/nestjs-bunyan",
+  "name": "@hydrow/nestjs-bunyan",
   "version": "0.5.7",
   "description": "Module and tooling for request-scoped Bunyan logging in NestJS.",
   "main": "dist",
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/eropple/nestjs-bunyan"
+    "url": "https://github.com/truerowing/nestjs-bunyan"
   },
   "private": false,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@eropple/nestjs-bunyan",
+  "name": "@hydrow/nestjs-bunyan",
   "version": "0.5.7",
   "description": "Module and tooling for request-scoped Bunyan logging in NestJS.",
   "main": "dist",

--- a/src/logging.module.ts
+++ b/src/logging.module.ts
@@ -40,7 +40,7 @@ export class LoggingModule {
           scope: Scope.REQUEST,
           inject: [ROOT_LOGGER, REQUEST],
           useFactory: (rootLogger: Bunyan, request: ExpressRequest) => {
-            const rawId = request ? request.headers[correlationIdHeader] : [];
+            const rawId = (request && request.headers) ? request.headers[correlationIdHeader] : [];
             const correlationId = flatten<string | undefined>([rawId])[0] || "NO_CORRELATION_ID_FOUND";
 
             const requestLogger = rootLogger.child({ correlationId });

--- a/src/logging.module.ts
+++ b/src/logging.module.ts
@@ -43,7 +43,7 @@ export class LoggingModule {
             const rawId = (request && request.headers) ? request.headers[correlationIdHeader] : [];
             const correlationId = flatten<string | undefined>([rawId])[0] || "NO_CORRELATION_ID_FOUND";
 
-            const requestLogger = rootLogger.child({ correlationId });
+            const requestLogger = rootLogger.child({ correlationId, 'req-id': correlationId });
             if (options.postRequestCreate) {
               const newFields = options.postRequestCreate(requestLogger, request);
               requestLogger.fields = { ...requestLogger.fields, ...newFields };


### PR DESCRIPTION
This pull request adds `req-id` in addition to `correlationId` to match the Bunyan standard and Hydrow tablet software.

It implements the chore https://www.pivotaltracker.com/story/show/175415919